### PR TITLE
Allow running headless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,9 @@ WORKDIR /rocrail
 
 COPY entrypoint.sh /
 
+EXPOSE 161
+EXPOSE 4303
 EXPOSE 8051
+EXPOSE 8088
+
 ENTRYPOINT ["/usr/bin/tini", "--",  "/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,5 +4,4 @@ if [[ ! -e svg ]]
 then
 	ln -svi /opt/rocrail/svg .
 fi
-/opt/rocrail/bin/rocrail -l /opt/rocrail/bin > /tmp/rocrail.log 2>&1 &
-/opt/rocrail/bin/rocview -sp /opt/rocrail/bin -dp /opt/rocrail/demo
+/opt/rocrail/bin/rocrail -l /opt/rocrail/bin

--- a/rocker.sh
+++ b/rocker.sh
@@ -11,9 +11,17 @@ then
 	ln -svi /opt/rocrail/svg .
 	popd
 fi
-${DOCKER} run -it --rm \
-    --env="DISPLAY" \
+
+CONTAINER_ID=$(${DOCKER} container run --rm -d \
+    -u $(id -u):$(id -g) \
     --publish-all \
     --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
     --volume="${ROCRAIL_DIR}:/rocrail:rw" \
-    rocrail:${ROCRAIL_VERSION} $*
+    rocrail:${ROCRAIL_VERSION} $*)
+
+${DOCKER} container exec \
+    --env="DISPLAY=$DISPLAY" \
+    ${CONTAINER_ID} \
+    /opt/rocrail/bin/rocview -sp /opt/rocrail/bin -dp /opt/rocrail/demo
+
+${DOCKER} container stop $CONTAINER_ID


### PR DESCRIPTION
Don't start rocview from entrypoint, but launch from rocker.sh
after the container started. Also expose all network services.